### PR TITLE
Move to new GitHub organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Get the latest beer on tap at East Nashville Beer Works
 
-[![npm version](https://badge.fury.io/js/hubot-enbw.svg)](http://badge.fury.io/js/hubot-enbw) [![Build Status](https://travis-ci.org/stephenyeargin/hubot-enbw.png)](https://travis-ci.org/stephenyeargin/hubot-enbw)
+[![npm version](https://badge.fury.io/js/hubot-enbw.svg)](http://badge.fury.io/js/hubot-enbw) [![Build Status](https://travis-ci.com/ENBW/hubot-enbw.png)](https://travis-ci.org/ENBW/hubot-enbw)
 
 See [`src/enbw.coffee`](src/enbw.coffee) for full documentation.
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "keywords": "hubot, hubot-scripts, beer, east nashville, east nashville beer works, enbw",
   "repository": {
     "type": "git",
-    "url": "git://github.com/stephenyeargin/hubot-enbw.git"
+    "url": "git://github.com/ENBW/hubot-enbw.git"
   },
   "bugs": {
-    "url": "https://github.com/stephenyeargin/hubot-enbw/issues"
+    "url": "https://github.com/ENBW/hubot-enbw/issues"
   },
   "dependencies": {
     "asciitable": "0.0.7"


### PR DESCRIPTION
Update links and images to point to @ENBW.